### PR TITLE
DbCredentials, TimeInterval and DatacubeQueryContext classes

### DIFF
--- a/api-examples/source/main/python/tool/summarise_dataset_time_series_statistics.py
+++ b/api-examples/source/main/python/tool/summarise_dataset_time_series_statistics.py
@@ -1,0 +1,606 @@
+#!/usr/bin/env python
+
+# ===============================================================================
+# Copyright (c)  2014 Geoscience Australia
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+# * Neither Geoscience Australia nor the names of its contributors may be
+# used to endorse or promote products derived from this software
+# without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# ===============================================================================
+import gc
+
+
+__author__ = "Simon Oldfield"
+
+import argparse
+import gdal
+import numpy
+from gdalconst import GA_Update
+import logging
+import os
+import resource
+from datetime import datetime, timedelta
+from datacube.api.model import DatasetType, Satellite, get_bands, dataset_type_database
+from datacube.api.query import list_tiles_as_list
+from datacube.api.utils import PqaMask, get_dataset_metadata, get_dataset_data, get_dataset_data_with_pq, empty_array
+from datacube.api.utils import NDV, UINT16_MAX
+from datacube.api.workflow import writeable_dir
+from datacube.config import Config
+from enum import Enum
+
+
+_log = logging.getLogger()
+
+
+def satellite_arg(s):
+    if s in Satellite._member_names_:
+        return Satellite[s]
+    raise argparse.ArgumentTypeError("{0} is not a supported satellite".format(s))
+
+
+def pqa_mask_arg(s):
+    if s in PqaMask._member_names_:
+        return PqaMask[s]
+    raise argparse.ArgumentTypeError("{0} is not a supported PQA mask".format(s))
+
+
+def dataset_type_arg(s):
+    if s in DatasetType._member_names_:
+        return DatasetType[s]
+    raise argparse.ArgumentTypeError("{0} is not a supported dataset type".format(s))
+
+
+def statistic_arg(s):
+    if s in Statistic._member_names_:
+        return Statistic[s]
+    raise argparse.ArgumentTypeError("{0} is not a supported statistic".format(s))
+
+
+class Statistic(Enum):
+    __order__ = "COUNT MIN MAX MEAN MEDIAN SUM STANDARD_DEVIATION VARIANCE PERCENTILE_25 PERCENTILE_50 PERCENTILE_75 PERCENTILE_90 PERCENTILE_95"
+
+    COUNT = "COUNT"
+    MIN = "MIN"
+    MAX = "MAX"
+    MEAN = "MEAN"
+    MEDIAN = "MEDIAN"
+    SUM = "SUM"
+    STANDARD_DEVIATION = "STANDARD_DEVIATION"
+    VARIANCE = "VARIANCE"
+    PERCENTILE_25 = "PERCENTILE_25"
+    PERCENTILE_50 = "PERCENTILE_50"
+    PERCENTILE_75 = "PERCENTILE_75"
+    PERCENTILE_90 = "PERCENTILE_90"
+    PERCENTILE_95 = "PERCENTILE_95"
+
+
+class SummariseDatasetTimeSeriesStatistics():
+    application_name = None
+
+    x = None
+    y = None
+
+    acq_min = None
+    acq_max = None
+
+    process_min = None
+    process_max = None
+
+    ingest_min = None
+    ingest_max = None
+
+    satellites = None
+
+    apply_pqa_filter = None
+    pqa_mask = None
+
+    dataset_type = None
+
+    output_directory = None
+    overwrite = None
+    list_only = None
+
+    statistics = None
+    percentiles = None
+
+    chunk_size_x = None
+    chunk_size_y = None
+
+    def __init__(self, application_name):
+        self.application_name = application_name
+
+    def parse_arguments(self):
+        parser = argparse.ArgumentParser(prog=__name__, description=self.application_name)
+
+        group = parser.add_mutually_exclusive_group()
+
+        group.add_argument("--quiet", help="Less output", action="store_const", dest="log_level", const=logging.WARN)
+        group.add_argument("--verbose", help="More output", action="store_const", dest="log_level", const=logging.DEBUG)
+
+        parser.set_defaults(log_level=logging.INFO)
+
+        parser.add_argument("--x", help="X grid reference", action="store", dest="x",
+                            type=int, choices=range(110, 155 + 1), required=True, metavar="[110 - 155]")
+        parser.add_argument("--y", help="Y grid reference", action="store", dest="y",
+                            type=int, choices=range(-45, -10 + 1), required=True, metavar="[-45 - -10]")
+
+        parser.add_argument("--acq-min", help="Acquisition Date (YYYY or YYYY-MM or YYYY-MM-DD)", action="store",
+                            dest="acq_min", type=str, default="1980")
+        parser.add_argument("--acq-max", help="Acquisition Date (YYYY or YYYY-MM or YYYY-MM-DD)", action="store",
+                            dest="acq_max", type=str, default="2020")
+
+        # parser.add_argument("--process-min", help="Process Date", action="store", dest="process_min", type=str)
+        # parser.add_argument("--process-max", help="Process Date", action="store", dest="process_max", type=str)
+        #
+        # parser.add_argument("--ingest-min", help="Ingest Date", action="store", dest="ingest_min", type=str)
+        # parser.add_argument("--ingest-max", help="Ingest Date", action="store", dest="ingest_max", type=str)
+
+        parser.add_argument("--satellite", help="The satellite(s) to include", action="store", dest="satellite",
+                            type=satellite_arg, nargs="+", choices=Satellite, default=[Satellite.LS5, Satellite.LS7],
+                            metavar=" ".join([s.name for s in Satellite]))
+
+        parser.add_argument("--apply-pqa", help="Apply PQA mask", action="store_true", dest="apply_pqa", default=False)
+        parser.add_argument("--pqa-mask", help="The PQA mask to apply", action="store", dest="pqa_mask",
+                            type=pqa_mask_arg, nargs="+", choices=PqaMask, default=[PqaMask.PQ_MASK_CLEAR],
+                            metavar=" ".join([s.name for s in PqaMask]))
+
+        supported_dataset_types = dataset_type_database
+
+        parser.add_argument("--dataset-type", help="The type of dataset to retrieve", action="store",
+                            dest="dataset_type",
+                            type=dataset_type_arg,
+                            choices=supported_dataset_types, default=DatasetType.ARG25,
+                            metavar=" ".join([s.name for s in supported_dataset_types]))
+
+        parser.add_argument("--output-directory", help="Output directory", action="store", dest="output_directory",
+                            type=writeable_dir, required=True)
+
+        parser.add_argument("--overwrite", help="Over write existing output file", action="store_true",
+                            dest="overwrite", default=False)
+
+        parser.add_argument("--list-only", help="List the datasets that would be retrieved rather than retrieving them",
+                            action="store_true", dest="list_only", default=False)
+
+        supported_statistics = [
+            Statistic.COUNT,
+            Statistic.MIN,
+            Statistic.MAX,
+            Statistic.MEAN,
+            Statistic.MEDIAN,
+            Statistic.SUM,
+            Statistic.STANDARD_DEVIATION,
+            Statistic.VARIANCE,
+            Statistic.PERCENTILE_25,
+            Statistic.PERCENTILE_50,
+            Statistic.PERCENTILE_75,
+            Statistic.PERCENTILE_90,
+            Statistic.PERCENTILE_95]
+
+        parser.add_argument("--statistic", help="The statistic(s) to calculate", action="store",
+                            dest="statistics",
+                            type=statistic_arg,
+                            nargs="+",
+                            choices=supported_statistics,
+                            default=supported_statistics,
+                            metavar=" ".join([s.name for s in supported_statistics]))
+
+        # parser.add_argument("--percentile", help="The percentile value(s) calculate", action="store",
+        #                     dest="percentile",
+        #                     type=int,
+        #                     nargs="+",
+        #                     choices=range(0, 100 + 1), required=False, default=[25, 50, 75, 90, 95],
+        #                     metavar="[0 - 100]")
+
+        parser.add_argument("--chunk-size-x", help="Number of X pixels to process at once", action="store",
+                            dest="chunk_size_x", type=int, choices=range(0, 4000 + 1), default=4000,
+                            metavar="[1 - 4000]")
+        parser.add_argument("--chunk-size-y", help="Number of Y pixels to process at once", action="store",
+                            dest="chunk_size_y", type=int, choices=range(0, 4000 + 1), default=4000,
+                            metavar="[1 - 4000]")
+
+        args = parser.parse_args()
+
+        _log.setLevel(args.log_level)
+
+        self.x = args.x
+        self.y = args.y
+
+        def parse_date_min(s):
+            from datetime import datetime
+
+            if s:
+                if len(s) == len("YYYY"):
+                    return datetime.strptime(s, "%Y").date()
+
+                elif len(s) == len("YYYY-MM"):
+                    return datetime.strptime(s, "%Y-%m").date()
+
+                elif len(s) == len("YYYY-MM-DD"):
+                    return datetime.strptime(s, "%Y-%m-%d").date()
+
+            return None
+
+        def parse_date_max(s):
+            from datetime import datetime
+            import calendar
+
+            if s:
+                if len(s) == len("YYYY"):
+                    d = datetime.strptime(s, "%Y").date()
+                    d = d.replace(month=12, day=31)
+                    return d
+
+                elif len(s) == len("YYYY-MM"):
+                    d = datetime.strptime(s, "%Y-%m").date()
+
+                    first, last = calendar.monthrange(d.year, d.month)
+                    d = d.replace(day=last)
+                    return d
+
+                elif len(s) == len("YYYY-MM-DD"):
+                    d = datetime.strptime(s, "%Y-%m-%d").date()
+                    return d
+
+            return None
+
+        self.acq_min = parse_date_min(args.acq_min)
+        self.acq_max = parse_date_max(args.acq_max)
+
+        # self.process_min = parse_date_min(args.process_min)
+        # self.process_max = parse_date_max(args.process_max)
+        #
+        # self.ingest_min = parse_date_min(args.ingest_min)
+        # self.ingest_max = parse_date_max(args.ingest_max)
+
+        self.satellites = args.satellite
+
+        self.apply_pqa_filter = args.apply_pqa
+        self.pqa_mask = args.pqa_mask
+
+        self.dataset_type = args.dataset_type
+
+        self.output_directory = args.output_directory
+        self.overwrite = args.overwrite
+        self.list_only = args.list_only
+
+        self.statistics = args.statistics
+
+        self.chunk_size_x = args.chunk_size_x
+        self.chunk_size_y = args.chunk_size_y
+
+        _log.info("""
+        x = {x:03d}
+        y = {y:04d}
+        acq = {acq_min} to {acq_max}
+        process = {process_min} to {process_max}
+        ingest = {ingest_min} to {ingest_max}
+        satellites = {satellites}
+        apply PQA filter = {apply_pqa_filter}
+        PQA mask = {pqa_mask}
+        datasets to retrieve = {dataset_type}
+        output directory = {output}
+        over write existing = {overwrite}
+        list only = {list_only}
+        statistics = {statistics}
+        percentiles = {percentiles}
+        chunk size = {chunk_size_x:4d} x {chunk_size_y:4d} pixels
+        """.format(x=self.x, y=self.y,
+                   acq_min=self.acq_min, acq_max=self.acq_max,
+                   process_min=self.process_min, process_max=self.process_max,
+                   ingest_min=self.ingest_min, ingest_max=self.ingest_max,
+                   satellites=self.satellites,
+                   apply_pqa_filter=self.apply_pqa_filter, pqa_mask=self.pqa_mask,
+                   dataset_type=decode_dataset_type(self.dataset_type),
+                   output=self.output_directory,
+                   overwrite=self.overwrite,
+                   list_only=self.list_only,
+                   statistics=self.statistics,
+                   percentiles=self.percentiles,
+                   chunk_size_x=self.chunk_size_x,
+                   chunk_size_y=self.chunk_size_y))
+
+    # The basic logic here is:
+    #
+    # for each chunk:
+    # for each band:
+    #       for each tile
+    #           read data for chunk of tile and append to time series array
+    #
+    #       for each statistic:
+    #           calculate statistic over time series array
+    #           write statistic to output file
+
+    def run(self):
+        self.parse_arguments()
+
+        config = Config(os.path.expanduser("~/.datacube/config"))
+        _log.debug(config.to_str())
+
+        # TODO
+        bands = get_bands(self.dataset_type, self.satellites[0])
+
+        paths = dict()
+
+        # Check output files
+        for band in bands:
+            paths[band] = self.get_output_filename(band)
+            _log.info("Output file for band [%s] is [%s]", band.name, paths[band])
+
+            if os.path.exists(paths[band]):
+                if self.overwrite:
+                    _log.info("Removing existing output file [%s]", paths[band])
+                    os.remove(paths[band])
+                else:
+                    _log.error("Output file [%s] exists", paths[band])
+                    raise Exception("Output file [%s] already exists" % paths[band])
+
+        tiles = list_tiles_as_list(x=[self.x], y=[self.y], acq_min=self.acq_min, acq_max=self.acq_max,
+                                   satellites=[satellite for satellite in self.satellites],
+                                   datasets=[self.dataset_type],
+                                   database=config.get_db_database(),
+                                   user=config.get_db_username(),
+                                   password=config.get_db_password(),
+                                   host=config.get_db_host(), port=config.get_db_port())
+
+        raster = None
+        metadata = None
+
+        # TODO - PQ is UINT16 (others are INT16) and so -999 NDV doesn't work
+        ndv = self.dataset_type == DatasetType.PQ25 and UINT16_MAX or NDV
+
+        _log.debug("Current MAX RSS  usage is [%d] MB", resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024)
+
+        import itertools
+
+        for band in bands:
+
+            for x, y in itertools.product(range(0, 4000, self.chunk_size_x), range(0, 4000, self.chunk_size_y)):
+
+                _log.debug("Current MAX RSS  usage is [%d] MB", resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024)
+
+                stack = list()
+
+                for tile in tiles:
+
+                    if self.list_only:
+                        _log.info("Would summarise dataset [%s]", tile.datasets[self.dataset_type].path)
+                        continue
+
+                    pqa = None
+
+                    _log.info("About to read data chunk ({xmin:4d},{ymin:4d}) to ({xmax:4d},{ymax:4d}) for band {band} from file {file}".format(xmin=x, ymin=y,
+                                                                                                               xmax=x + self.chunk_size_x - 1,
+                                                                                                               ymax=y + self.chunk_size_y - 1,
+                                                                                                               band=band.name,  file=tile.datasets[self.dataset_type].path))
+                    _log.debug("Reading dataset [%s]", tile.datasets[self.dataset_type].path)
+
+                    if not metadata:
+                        metadata = get_dataset_metadata(tile.datasets[self.dataset_type])
+
+                    # Apply PQA if specified
+
+                    if self.apply_pqa_filter:
+                        data = get_dataset_data_with_pq(tile.datasets[self.dataset_type], tile.datasets[DatasetType.PQ25],
+                                                        bands=[band], x=x, y=y, x_size=self.chunk_size_x,
+                                                        y_size=self.chunk_size_y, pq_masks=self.pqa_mask, ndv=ndv)
+
+                    else:
+                        data = get_dataset_data(tile.datasets[self.dataset_type], bands=[band], x=x, y=y,
+                                                x_size=self.chunk_size_x, y_size=self.chunk_size_y)
+
+                    stack.append(data[band])
+
+                    _log.debug("data[%s] has shape [%s] and MB [%s]", band.name, numpy.shape(data[band]), data[band].nbytes / 1000 / 1000)
+                    _log.debug("stack[%s] has [%s] elements", band.name, len(stack))
+
+                # Apply summary method
+
+                _log.info(
+                    "Finished reading {count} datasets for chunk ({xmin:4d},{ymin:4d}) to ({xmax:4d},{ymax:4d}) - about to summarise them".format(
+                        count=len(tiles), xmin=x, ymin=y, xmax=x + self.chunk_size_x - 1, ymax=y + self.chunk_size_y - 1))
+                _log.debug("Current MAX RSS  usage is [%d] MB", resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024)
+
+                masked_stack = numpy.ma.masked_equal(stack, ndv)
+
+                _log.debug("masked_stack[%s] is %s", band.name, masked_stack)
+                _log.debug("masked stack[%s] has shape [%s] and MB [%s]", band.name, numpy.shape(masked_stack), masked_stack.nbytes / 1000 / 1000)
+                _log.debug("Current MAX RSS  usage is [%d] MB", resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024)
+
+                del stack
+                _log.debug("Just NONE-ed the stack")
+                _log.debug("Current MAX RSS  usage is [%d] MB", resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024)
+
+                mask_sorted = None
+
+                for statistic in self.statistics:
+                    _log.info("Calculating statistic [%s]", statistic.name)
+
+                    if statistic == Statistic.COUNT:
+                        # TODO Need to artificially create masked array here since it is being expected/filled below!!!
+                        masked_summary = numpy.ma.masked_equal(masked_stack.count(axis=0), ndv)
+
+                    elif statistic == Statistic.MIN:
+                        masked_summary = numpy.min(masked_stack, axis=0)
+
+                    elif statistic == Statistic.MAX:
+                        masked_summary = numpy.max(masked_stack, axis=0)
+
+                    elif statistic == Statistic.MEAN:
+                        masked_summary = numpy.mean(masked_stack, axis=0)
+
+                    elif statistic == Statistic.MEDIAN:
+                        masked_summary = numpy.median(masked_stack, axis=0)
+
+                    elif statistic == Statistic.SUM:
+                        masked_summary = numpy.sum(masked_stack, axis=0)
+
+                    elif statistic == Statistic.STANDARD_DEVIATION:
+                        masked_summary = numpy.std(masked_stack, axis=0)
+
+                    elif statistic == Statistic.VARIANCE:
+                        masked_summary = numpy.var(masked_stack, axis=0)
+
+                    elif statistic == Statistic.PERCENTILE_25:
+                        if not mask_sorted:
+                            masked_sorted = numpy.ma.sort(masked_stack, axis=0)
+                        masked_percentile_index = numpy.ma.floor(numpy.ma.count(masked_sorted, axis=0) * 0.25).astype(numpy.int16)
+                        masked_summary = numpy.ma.choose(masked_percentile_index, masked_sorted)
+                        del masked_percentile_index
+
+                    elif statistic == Statistic.PERCENTILE_50:
+                        if not mask_sorted:
+                            masked_sorted = numpy.ma.sort(masked_stack, axis=0)
+                        masked_percentile_index = numpy.ma.floor(numpy.ma.count(masked_sorted, axis=0) * 0.50).astype(numpy.int16)
+                        masked_summary = numpy.ma.choose(masked_percentile_index, masked_sorted)
+                        del masked_percentile_index
+
+                    elif statistic == Statistic.PERCENTILE_75:
+                        if not mask_sorted:
+                            masked_sorted = numpy.ma.sort(masked_stack, axis=0)
+                        masked_percentile_index = numpy.ma.floor(numpy.ma.count(masked_sorted, axis=0) * 0.75).astype(numpy.int16)
+                        masked_summary = numpy.ma.choose(masked_percentile_index, masked_sorted)
+                        del masked_percentile_index
+
+                    elif statistic == Statistic.PERCENTILE_90:
+                        if not mask_sorted:
+                            masked_sorted = numpy.ma.sort(masked_stack, axis=0)
+                        masked_percentile_index = numpy.ma.floor(numpy.ma.count(masked_sorted, axis=0) * 0.90).astype(numpy.int16)
+                        masked_summary = numpy.ma.choose(masked_percentile_index, masked_sorted)
+                        del masked_percentile_index
+
+                    elif statistic == Statistic.PERCENTILE_95:
+                        if not mask_sorted:
+                            masked_sorted = numpy.ma.sort(masked_stack, axis=0)
+                        masked_percentile_index = numpy.ma.floor(numpy.ma.count(masked_sorted, axis=0) * 0.95).astype(numpy.int16)
+                        masked_summary = numpy.ma.choose(masked_percentile_index, masked_sorted)
+                        del masked_percentile_index
+
+                    _log.debug("masked summary is [%s]", masked_summary)
+                    _log.debug("Current MAX RSS  usage is [%d] MB", resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024)
+
+                    # Create the output file
+
+                    if not os.path.exists(paths[band]):
+                        _log.info("Creating raster [%s]", paths[band])
+
+                        driver = gdal.GetDriverByName("GTiff")
+                        assert driver
+
+                        raster = driver.Create(paths[band], metadata.shape[0], metadata.shape[1], len(self.statistics), gdal.GDT_Int16)
+                        assert raster
+
+                        raster.SetGeoTransform(metadata.transform)
+                        raster.SetProjection(metadata.projection)
+
+                    _log.info("Setting no data value for band [%s] which has index [%d]", statistic.name, self.statistics.index(statistic) + 1)
+                    raster.GetRasterBand(self.statistics.index(statistic) + 1).SetNoDataValue(ndv)
+
+                    _log.info("Writing band [%s] data to raster [%s]", band.name, paths[band])
+                    _log.debug("Current MAX RSS  usage is [%d] MB", resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024)
+
+                    _log.info("masked_summary has shape [%s]", numpy.shape(masked_summary))
+                    _log.info("masked_summary has data\n[%s]", masked_summary)
+
+                    raster.GetRasterBand(self.statistics.index(statistic) + 1).WriteArray(masked_summary.filled(ndv), xoff=x, yoff=y)
+                    raster.GetRasterBand(self.statistics.index(statistic) + 1).ComputeStatistics(True)
+
+                    raster.FlushCache()
+
+                    del masked_summary
+                    _log.debug("NONE-ing the masked summary")
+                    _log.debug("Current MAX RSS  usage is [%d] MB", resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024)
+
+                del masked_stack
+                _log.debug("NONE-ing masked stack[%s]", band.name)
+                _log.debug("Current MAX RSS  usage is [%d] MB", resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024)
+
+                del masked_sorted
+                _log.debug("NONE-ing masked sorted[%s]", band.name)
+                _log.debug("Current MAX RSS  usage is [%d] MB", resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024)
+
+            del raster
+
+            _log.debug("Just NONE'd the raster")
+            _log.debug("Current MAX RSS  usage is [%d] MB", resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024)
+
+        _log.info("Memory usage was [%d MB]", resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024)
+        _log.info("CPU time used [%s]", timedelta(seconds=int(resource.getrusage(resource.RUSAGE_SELF).ru_utime)))
+
+    def get_output_filename(self, band):
+
+        if self.dataset_type == DatasetType.WATER:
+            return os.path.join(self.output_directory,
+                                "LS_WOFS_SUMMARY_{x:03d}_{y:04d}_{acq_min}_{acq_max}.tif".format(latitude=self.x,
+                                                                                                 longitude=self.y,
+                                                                                                 acq_min=self.acq_min,
+                                                                                                 acq_max=self.acq_max))
+        satellite_str = ""
+
+        if Satellite.LS5 in self.satellites or Satellite.LS7 in self.satellites or Satellite.LS8 in self.satellites:
+            satellite_str += "LS"
+
+        if Satellite.LS5 in self.satellites:
+            satellite_str += "5"
+
+        if Satellite.LS7 in self.satellites:
+            satellite_str += "7"
+
+        if Satellite.LS8 in self.satellites:
+            satellite_str += "8"
+
+        dataset_str = ""
+
+        if self.dataset_type == DatasetType.ARG25:
+            dataset_str += "NBAR"
+
+        elif self.dataset_type == DatasetType.PQ25:
+            dataset_str += "PQA"
+
+        elif self.dataset_type == DatasetType.FC25:
+            dataset_str += "FC"
+
+        elif self.dataset_type == DatasetType.WATER:
+            dataset_str += "WOFS"
+
+        if self.apply_pqa_filter:
+            dataset_str += "_WITH_PQA"
+
+        return os.path.join(self.output_directory,
+                            "{satellite}_{dataset}_STATISTICS_{x:03d}_{y:04d}_{acq_min}_{acq_max}_{band}.tif".format(
+                                satellite=satellite_str, dataset=dataset_str, x=self.x, y=self.y,
+                                acq_min=self.acq_min, acq_max=self.acq_max, band=band.name))
+
+
+def decode_dataset_type(dataset_type):
+    return {DatasetType.ARG25: "Surface Reflectance",
+            DatasetType.PQ25: "Pixel Quality",
+            DatasetType.FC25: "Fractional Cover",
+            DatasetType.WATER: "WOFS Woffle",
+            DatasetType.NDVI: "NDVI",
+            DatasetType.EVI: "EVI",
+            DatasetType.NBR: "Normalised Burn Ratio"}[dataset_type]
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO)
+
+    SummariseDatasetTimeSeriesStatistics("Summarise Dataset Time Series - Statistics").run()

--- a/api/source/main/python/datacube/api/model.py
+++ b/api/source/main/python/datacube/api/model.py
@@ -174,8 +174,6 @@ class DatasetTile:
     bands = None
 
     def __init__(self, satellite_id, type_id, path):
-        _log.debug("Creating DatasetTile from satellite_id=[%s] type_id=[%s] path=[%s]", satellite_id, type_id, path)
-
         self.satellite = satellite_id and Satellite[satellite_id] or None
         self.dataset_type = DatasetType[type_id]
         self.path = warp_file_paths(path)

--- a/api/source/main/python/datacube/api/model.py
+++ b/api/source/main/python/datacube/api/model.py
@@ -157,7 +157,7 @@ class DatasetType(Enum):
     NBR = "NBR"
 
 
-dataset_type_database = [DatasetType.ARG25, DatasetType.PQ25, DatasetType.FC25]
+dataset_type_database = [DatasetType.ARG25, DatasetType.PQ25, DatasetType.FC25, DatasetType.DSM, DatasetType.DEM, DatasetType.DEM_HYDROLOGICALLY_ENFORCED, DatasetType.DEM_SMOOTHED]
 dataset_type_filesystem = [DatasetType.WATER]
 dataset_type_derived_nbar = [DatasetType.NDVI, DatasetType.EVI, DatasetType.NBR] # TCI, SAVI, etc...
 
@@ -289,8 +289,8 @@ class Tile:
         self.xy = (self.x, self.y)  # TODO
         self.start_datetime = start_datetime
         self.end_datetime = end_datetime
-        self.end_datetime_year = int(end_datetime_year)
-        self.end_datetime_month = int(end_datetime_month)
+        self.end_datetime_year = end_datetime_year and int(end_datetime_year) or None
+        self.end_datetime_month = end_datetime_month and int(end_datetime_month) or None
         self.datasets = datasets
 
     @staticmethod
@@ -319,7 +319,8 @@ class Tile:
             datasets=DatasetTile.from_db_array(record["satellite"], record["datasets"]))
 
 
-# TODO Need to deal with the fact that some datasets don't have a satellite
+# TODO Need to deal with the fact that some datasets don't have a satellite and stuff
+
 BANDS = {
     (DatasetType.ARG25, Satellite.LS5): Ls57Arg25Bands,
     (DatasetType.ARG25, Satellite.LS7): Ls57Arg25Bands,
@@ -337,21 +338,10 @@ BANDS = {
     (DatasetType.WATER, Satellite.LS7): Wofs25Bands,
     (DatasetType.WATER, Satellite.LS8): Wofs25Bands,
 
-    (DatasetType.DSM, Satellite.LS5): DsmBands,
-    (DatasetType.DSM, Satellite.LS7): DsmBands,
-    (DatasetType.DSM, Satellite.LS8): DsmBands,
-
-    (DatasetType.DEM, Satellite.LS5): DsmBands,
-    (DatasetType.DEM, Satellite.LS7): DsmBands,
-    (DatasetType.DEM, Satellite.LS8): DsmBands,
-
-    (DatasetType.DEM_SMOOTHED, Satellite.LS5): DsmBands,
-    (DatasetType.DEM_SMOOTHED, Satellite.LS7): DsmBands,
-    (DatasetType.DEM_SMOOTHED, Satellite.LS8): DsmBands,
-
-    (DatasetType.DEM_HYDROLOGICALLY_ENFORCED, Satellite.LS5): DsmBands,
-    (DatasetType.DEM_HYDROLOGICALLY_ENFORCED, Satellite.LS7): DsmBands,
-    (DatasetType.DEM_HYDROLOGICALLY_ENFORCED, Satellite.LS8): DsmBands
+    (DatasetType.DSM, None): DsmBands,
+    (DatasetType.DEM, None): DsmBands,
+    (DatasetType.DEM_SMOOTHED, None): DsmBands,
+    (DatasetType.DEM_HYDROLOGICALLY_ENFORCED, None): DsmBands,
 }
 
 

--- a/api/source/main/python/datacube/api/query.py
+++ b/api/source/main/python/datacube/api/query.py
@@ -1243,12 +1243,12 @@ class TimeInterval(object):
             TimeInterval(end_datetime=datetime(2013,1,1)) # all time up to the end of 2012
             TimeInterval() # all time (forever), aka: TimeInterval not specified
         """
-        assert(instanceof(start_datetime, datetime))
-        assert(instanceof(end_datetime, datetime))
+        assert(isinstance(start_datetime, datetime))
+        assert(isinstance(end_datetime, datetime))
         assert(end_datetime > start_datetime)
 
         self.start = start_datetime
-        self.end = start_end
+        self.end = end_datetime
 
 class DatacubeQueryContext(object):
     """
@@ -1261,18 +1261,19 @@ class DatacubeQueryContext(object):
         """
         self.db_credentials = db_credentials
 
-    def list_tiles(x_list, y_list, satellite_list, time_interval, dataset_list, sort=SortType.ASC):
-        return list_tiles( \
+    def tile_list(self, x_list, y_list, satellite_list, time_interval, dataset_list, sort=SortType.ASC):
+        print str(self.db_credentials)
+        return list_tiles_as_list( \
             x_list, \
             y_list, \
             satellite_list, \
             time_interval.start, \
             time_interval.end, \
             dataset_list, \
-            database=db_credentials.database, \
-            user=db_credentials.username, \
-            password=db_credentials.password, \
-            host=db_credentials.host, \
-            port=db_credentials.port, \
+            database=self.db_credentials.database, \
+            user=self.db_credentials.user, \
+            password=self.db_credentials.password, \
+            host=self.db_credentials.host, \
+            port=self.db_credentials.port, \
             sort=sort)
 

--- a/api/source/main/python/datacube/api/query.py
+++ b/api/source/main/python/datacube/api/query.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#st!/usr/bin/env python
 
 # ===============================================================================
 # Copyright (c)  2014 Geoscience Australia
@@ -1250,6 +1250,12 @@ class TimeInterval(object):
         self.start = start_datetime
         self.end = end_datetime
 
+    def years(self):
+        """
+        Return a list of years included in this interval
+        """
+        return range(self.start.year, self.end.year)
+
 class DatacubeQueryContext(object):
     """
     An instance of DatacubeQueryContext provides the ablility to query a selected Datacube
@@ -1270,6 +1276,21 @@ class DatacubeQueryContext(object):
             time_interval.start, \
             time_interval.end, \
             dataset_list, \
+            database=self.db_credentials.database, \
+            user=self.db_credentials.user, \
+            password=self.db_credentials.password, \
+            host=self.db_credentials.host, \
+            port=self.db_credentials.port, \
+            sort=sort)
+    
+    def tiles_to_file(self, x_list, y_list, satellite_list, time_interval, dataset_list, filename, sort=SortType.ASC):
+        return list_tiles_to_file(
+            x_list, \
+            y_list, \
+            satellite_list, \
+            time_interval.years(), \
+            dataset_list, \
+            filename, \
             database=self.db_credentials.database, \
             user=self.db_credentials.user, \
             password=self.db_credentials.password, \

--- a/api/source/main/python/datacube/api/query.py
+++ b/api/source/main/python/datacube/api/query.py
@@ -37,7 +37,7 @@ import psycopg2
 import psycopg2.extras
 import sys
 from model import Tile, Cell
-
+from datetime import datetime
 
 _log = logging.getLogger(__name__)
 
@@ -1216,3 +1216,63 @@ def list_tiles_wkt_to_file(wkt, years, datasets, format, filename, database, use
 
 def visit_tiles_wkt(wkt, years, datasets, database, user, password, host=None, port=None):
     pass
+
+
+class TimeInterval(object):
+    """
+    A TimeInterval represents an interval of time from a start instant up to (but not including)
+    an end instant. Instants are represented by datetime objects. Inspired by the Java JODA package.
+    """
+   
+    # define constants for the beginning and end of time
+    # NOTE: we could get rid of these but the SQL gets a bit messy
+
+    MIN_INSTANT = datetime(1900, 1, 1)
+    MAX_INSTANT = datetime(3999, 1, 1)
+       
+
+    def __init__(self, start_datetime=MIN_INSTANT, end_datetime=MAX_INSTANT):
+        """
+        Construct a TimeInterval object from the supplied start and end datetime instances.
+        Closed and open ended intervals (forwards and backwards) are supported, as is the "unspecified 
+        interval" consisting of all time (the "give me everything you've got" interval).
+
+        e.g:
+            TimeInterval(datetime(2013,1,1), datetime(2015,12,31))  # three years from 1/1/13
+            TimeInterval(datetime(2013,1,1))   # all time beginning from 1/1/13
+            TimeInterval(end_datetime=datetime(2013,1,1)) # all time up to the end of 2012
+            TimeInterval() # all time (forever), aka: TimeInterval not specified
+        """
+        assert(instanceof(start_datetime, datetime))
+        assert(instanceof(end_datetime, datetime))
+        assert(end_datetime > start_datetime)
+
+        self.start = start_datetime
+        self.end = start_end
+
+class DatacubeQueryContext(object):
+    """
+    An instance of DatacubeQueryContext provides the ablility to query a selected Datacube
+    """
+
+    def __init__(self, db_credentials):
+        """
+        Instantiate a new DatacubeQueryContext using the supplied DbCredentials object
+        """
+        self.db_credentials = db_credentials
+
+    def list_tiles(x_list, y_list, satellite_list, time_interval, dataset_list, sort=SortType.ASC):
+        return list_tiles( \
+            x_list, \
+            y_list, \
+            satellite_list, \
+            time_interval.start, \
+            time_interval.end, \
+            dataset_list, \
+            database=db_credentials.database, \
+            user=db_credentials.username, \
+            password=db_credentials.password, \
+            host=db_credentials.host, \
+            port=db_credentials.port, \
+            sort=sort)
+

--- a/api/source/main/python/datacube/api/query.py
+++ b/api/source/main/python/datacube/api/query.py
@@ -196,7 +196,7 @@ def list_cells_as_generator(x, y, satellites, acq_min, acq_max, datasets, databa
         """.format(sort=sort.value)
 
         params = {"tile_type": [1], "tile_class": [tile_class.value for tile_class in TILE_CLASSES],
-                  "satellite": satellites,
+                  "satellite": [satellite.value for satellite in satellites],
                   "x": x, "y": y,
                   "acq_min": acq_min, "acq_max": acq_max}
 

--- a/api/source/main/python/datacube/api/query.py
+++ b/api/source/main/python/datacube/api/query.py
@@ -95,6 +95,28 @@ def list_cells(x, y, satellites, acq_min, acq_max, datasets, database, user, pas
     return list_cells_as_generator(x, y, satellites, acq_min, acq_max, datasets, database, user, password, host, port, sort)
 
 
+def list_cells_as_list(x, y, satellites, acq_min, acq_max, datasets, database, user, password, host=None, port=None, sort=SortType.ASC):
+
+    """
+    Return a list of cells matching the criteria AS A REUSABLE LIST rather than as a one-use-generator
+
+    :type x: list[int]
+    :type y: list[int]
+    :type satellites: list[datacube.api.model.Satellite]
+    :type acq_min: datetime.date
+    :type acq_max: datetime.date
+    :type datasets: list[datacube.api.model.DatasetType]
+    :type database: str
+    :type user: str
+    :type password: str
+    :type host: str
+    :type port: int
+    :type sort: SortType
+    :rtype: list[datacube.api.model.Cell]
+    """
+    return list(list_cells(x, y, satellites, acq_min, acq_max, datasets, database, user, password, host, port, sort))
+
+
 def list_cells_as_generator(x, y, satellites, acq_min, acq_max, datasets, database, user, password, host=None, port=None, sort=SortType.ASC):
 
     """
@@ -214,28 +236,6 @@ def list_cells_as_generator(x, y, satellites, acq_min, acq_max, datasets, databa
         conn.rollback()
 
 
-def list_cells_as_list(x, y, satellites, acq_min, acq_max, datasets, database, user, password, host=None, port=None, sort=SortType.ASC):
-
-    """
-    Return a list of cells matching the criteria AS A REUSABLE LIST rather than as a one-use-generator
-
-    :type x: list[int]
-    :type y: list[int]
-    :type satellites: list[datacube.api.model.Satellite]
-    :type acq_min: datetime.date
-    :type acq_max: datetime.date
-    :type datasets: list[datacube.api.model.DatasetType]
-    :type database: str
-    :type user: str
-    :type password: str
-    :type host: str
-    :type port: int
-    :type sort: SortType
-    :rtype: list[datacube.api.model.Cell]
-    """
-    return list(list_cells(x, y, satellites, acq_min, acq_max, datasets, database, user, password, host, port, sort))
-
-
 def list_tiles(x, y, satellites, acq_min, acq_max, datasets, database, user, password, host=None, port=None, sort=SortType.ASC):
 
     """
@@ -258,6 +258,28 @@ def list_tiles(x, y, satellites, acq_min, acq_max, datasets, database, user, pas
     :rtype: list[datacube.api.model.Tile]
     """
     return list_tiles_as_generator(x, y, satellites, acq_min, acq_max, datasets, database, user, password, host, port, sort)
+
+
+def list_tiles_as_list(x, y, satellites, acq_min, acq_max, datasets, database, user, password, host=None, port=None, sort=SortType.ASC):
+
+    """
+    Return a list of cells matching the criteria AS A REUSABLE LIST rather than as a one-use-generator
+
+    :type x: list[int]
+    :type y: list[int]
+    :type satellites: list[datacube.api.model.Satellite]
+    :type acq_min: datetime.date
+    :type acq_max: datetime.date
+    :type datasets: list[datacube.api.model.DatasetType]
+    :type database: str
+    :type user: str
+    :type password: str
+    :type host: str
+    :type port: int
+    :type sort: SortType
+    :rtype: list[datacube.api.model.Tile]
+    """
+    return list(list_tiles(x, y, satellites, acq_min, acq_max, datasets, database, user, password, host, port, sort))
 
 
 def list_tiles_as_generator(x, y, satellites, acq_min, acq_max, datasets, database, user, password, host=None, port=None, sort=SortType.ASC):
@@ -432,16 +454,17 @@ def list_tiles_as_generator(x, y, satellites, acq_min, acq_max, datasets, databa
         conn.rollback()
 
 
-def list_tiles_as_list(x, y, satellites, acq_min, acq_max, datasets, database, user, password, host=None, port=None, sort=SortType.ASC):
+# Quickie to get DEM/DSM tiles for WOFS - note they have no acquisition information!!!!
+
+def list_tiles_dtm(x, y, datasets, database, user, password, host=None, port=None, sort=SortType.ASC):
 
     """
-    Return a list of cells matching the criteria AS A REUSABLE LIST rather than as a one-use-generator
+    Return a list of cells matching the criteria as a SINGLE-USE generator
+
+    Deprecated: Move to using explicit as_list or as_generator
 
     :type x: list[int]
     :type y: list[int]
-    :type satellites: list[datacube.api.model.Satellite]
-    :type acq_min: datetime.date
-    :type acq_max: datetime.date
     :type datasets: list[datacube.api.model.DatasetType]
     :type database: str
     :type user: str
@@ -451,7 +474,157 @@ def list_tiles_as_list(x, y, satellites, acq_min, acq_max, datasets, database, u
     :type sort: SortType
     :rtype: list[datacube.api.model.Tile]
     """
-    return list(list_tiles(x, y, satellites, acq_min, acq_max, datasets, database, user, password, host, port, sort))
+    return list_tiles_dtm_as_generator(x, y, datasets, database, user, password, host, port, sort)
+
+
+def list_tiles_dtm_as_list(x, y, datasets, database, user, password, host=None, port=None, sort=SortType.ASC):
+
+    """
+    Return a list of cells matching the criteria AS A REUSABLE LIST rather than as a one-use-generator
+
+    :type x: list[int]
+    :type y: list[int]
+    :type datasets: list[datacube.api.model.DatasetType]
+    :type database: str
+    :type user: str
+    :type password: str
+    :type host: str
+    :type port: int
+    :type sort: SortType
+    :rtype: list[datacube.api.model.Tile]
+    """
+    return list(list_tiles(x, y, datasets, database, user, password, host, port, sort))
+
+
+def list_tiles_dtm_as_generator(x, y, datasets, database, user, password, host=None, port=None, sort=SortType.ASC):
+
+    """
+    Return a list of cells matching the criteria as a SINGLE-USE generator
+
+    :type x: list[int]
+    :type y: list[int]
+    :type datasets: list[datacube.api.model.DatasetType]
+    :type database: str
+    :type user: str
+    :type password: str
+    :type host: str
+    :type port: int
+    :type sort: SortType
+    :rtype: list[datacube.api.model.Tile]
+    """
+
+    conn, cursor = None, None
+
+    try:
+        # connect to database
+
+        connection_string = ""
+
+        if host:
+            connection_string += "host={host}".format(host=host)
+
+        if port:
+            connection_string += " port={port}".format(port=port)
+
+        connection_string += " dbname={database} user={user} password={password}".format(database=database, user=user, password=password)
+
+        conn = psycopg2.connect(connection_string)
+
+        cursor = conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
+        cursor.execute("set search_path to {schema}, public".format(schema="gis, topology, ztmp"))
+
+        # Should the DB model be changed so that DATASET FKs to TILE not TILE FKs to DATASET?
+
+        # This query allows the user to specify
+        #   filter results by
+        #       x/y range
+        #
+        #   request which datasets they want
+        #       DSM
+        #       DEM
+        #       DEM SMOOTHED
+        #       DEM HYDROLOGICALLY ENFORCED
+
+        # It also needs to internally filter to
+        #   tile.tile_type_id in (1)
+        #   tile.tile_class_id in (1,3)
+
+        # select
+        #   dem.acquisition_id, tile.x_index, tile.y_index, tile.tile_pathname, tile.tile_type_id, tile.tile_class_id
+        # from tile
+        # join dataset dem on dem.dataset_id=tile.dataset_id and dem.level_id=100
+        # where tile.tile_type_id = 1 and tile.tile_class_id in (1,4) and tile.x_index in (120) and tile.y_index in (-20) ;
+
+        sql = """
+            select
+                null acquisition_id, null satellite, null start_datetime, null end_datetime,
+                null end_datetime_year, null end_datetime_month,
+                dsm.x_index, dsm.y_index, point(dsm.x_index, dsm.y_index) as xy,
+                ARRAY[
+                    ['DSM', DSM.tile_pathname],
+                    ['DEM', DEM.tile_pathname],
+                    ['DEM_HYDROLOGICALLY_ENFORCED', DEM_H.tile_pathname],
+                    ['DEM_SMOOTHED', DEM_S.tile_pathname]
+                    ] as datasets
+            from
+                (
+                select
+                    dataset.acquisition_id, tile.dataset_id, tile.x_index, tile.y_index, tile.tile_pathname, tile.tile_type_id, tile.tile_class_id
+                from tile
+                join dataset on dataset.dataset_id=tile.dataset_id
+                where dataset.level_id = 100
+                ) as DSM
+            join
+                (
+                select
+                    dataset.acquisition_id, tile.dataset_id, tile.x_index, tile.y_index, tile.tile_pathname, tile.tile_type_id, tile.tile_class_id
+                from tile
+                join dataset on dataset.dataset_id=tile.dataset_id
+                where dataset.level_id = 110
+                ) as DEM on
+                        DEM.x_index=DSM.x_index and DEM.y_index=DSM.y_index
+                    and DEM.tile_type_id=DSM.tile_type_id and DEM.tile_class_id=DSM.tile_class_id
+            join
+                (
+                select
+                    dataset.acquisition_id, tile.dataset_id, tile.x_index, tile.y_index, tile.tile_pathname, tile.tile_type_id, tile.tile_class_id
+                from tile
+                join dataset on dataset.dataset_id=tile.dataset_id
+                where dataset.level_id = 120
+                ) as DEM_S on
+                        DEM_S.x_index=DSM.x_index and DEM_S.y_index=DSM.y_index
+                    and DEM_S.tile_type_id=DSM.tile_type_id and DEM_S.tile_class_id=DSM.tile_class_id
+            join
+                (
+                select
+                    dataset.acquisition_id, tile.dataset_id, tile.x_index, tile.y_index, tile.tile_pathname, tile.tile_type_id, tile.tile_class_id
+                from tile
+                join dataset on dataset.dataset_id=tile.dataset_id
+                where dataset.level_id = 130
+                ) as DEM_H on
+                        DEM_H.x_index=DSM.x_index and DEM_H.y_index=DSM.y_index
+                    and DEM_H.tile_type_id=DSM.tile_type_id and DEM_H.tile_class_id=DSM.tile_class_id
+            where
+                DSM.tile_type_id = ANY(%(tile_type)s) and DSM.tile_class_id = ANY(%(tile_class)s) -- mandatory
+                and DSM.x_index = ANY(%(x)s) and DSM.y_index = ANY(%(y)s)
+            ;
+        """.format()
+
+        params = {"tile_type": [1], "tile_class": [tile_class.value for tile_class in TILE_CLASSES],
+                  "x": x, "y": y}
+
+        _log.debug(cursor.mogrify(sql, params))
+
+        cursor.execute(sql, params)
+
+        for record in result_generator(cursor):
+            _log.debug(record)
+            yield Tile.from_db_record(record)
+
+    except Exception as e:
+
+        _log.error("Caught exception %s", e)
+        conn.rollback()
 
 
 # TODO rename this to be the "standard" list_tiles and the above to be list_tiles_for_year or something

--- a/api/source/main/python/datacube/api/query.py
+++ b/api/source/main/python/datacube/api/query.py
@@ -343,15 +343,11 @@ def list_tiles_as_generator(x, y, satellites, acq_min, acq_max, datasets, databa
             select
                 acquisition.acquisition_id, satellite_tag as satellite, start_datetime, end_datetime,
                 extract(year from end_datetime) as end_datetime_year, extract(month from end_datetime) as end_datetime_month,
-                nbar.x_index, nbar.y_index, point(nbar.x_index, nbar.y_index) as xy,
+                NBAR.x_index, NBAR.y_index, point(NBAR.x_index, NBAR.y_index) as xy,
                 ARRAY[
-                    ['ARG25', nbar.tile_pathname],
-                    ['PQ25', pq.tile_pathname],
-                    ['FC25', fc.tile_pathname],
-                    ['DSM', DSM.tile_pathname],
-                    ['DEM', DEM.tile_pathname],
-                    ['DEM_HYDROLOGICALLY_ENFORCED', DEM_H.tile_pathname],
-                    ['DEM_SMOOTHED', DEM_S.tile_pathname]
+                    ['ARG25', NBAR.tile_pathname],
+                    ['PQ25', PQA.tile_pathname],
+                    ['FC25', FC.tile_pathname]
                     ] as datasets
             from acquisition
             join satellite on satellite.satellite_id=acquisition.satellite_id
@@ -362,7 +358,7 @@ def list_tiles_as_generator(x, y, satellites, acq_min, acq_max, datasets, databa
                 from tile
                 join dataset on dataset.dataset_id=tile.dataset_id
                 where dataset.level_id = 2
-                ) as nbar on nbar.acquisition_id=acquisition.acquisition_id
+                ) as NBAR on nbar.acquisition_id=acquisition.acquisition_id
             join
                 (
                 select
@@ -370,10 +366,10 @@ def list_tiles_as_generator(x, y, satellites, acq_min, acq_max, datasets, databa
                 from tile
                 join dataset on dataset.dataset_id=tile.dataset_id
                 where dataset.level_id = 3
-                ) as pq on
-                    pq.acquisition_id=acquisition.acquisition_id
-                    and pq.x_index=nbar.x_index and pq.y_index=nbar.y_index
-                    and pq.tile_type_id=nbar.tile_type_id and pq.tile_class_id=nbar.tile_class_id
+                ) as PQA on
+                    PQA.acquisition_id=acquisition.acquisition_id
+                    and PQA.x_index=NBAR.x_index and PQA.y_index=NBAR.y_index
+                    and PQA.tile_type_id=NBAR.tile_type_id and PQA.tile_class_id=NBAR.tile_class_id
             join
                 (
                 select
@@ -381,54 +377,14 @@ def list_tiles_as_generator(x, y, satellites, acq_min, acq_max, datasets, databa
                 from tile
                 join dataset on dataset.dataset_id=tile.dataset_id
                 where dataset.level_id = 4
-                ) as fc on
-                    fc.acquisition_id=acquisition.acquisition_id
-                    and fc.x_index=nbar.x_index and fc.y_index=nbar.y_index
-                    and fc.tile_type_id=nbar.tile_type_id and fc.tile_class_id=nbar.tile_class_id
-            join
-                (
-                select
-                    dataset.acquisition_id, tile.dataset_id, tile.x_index, tile.y_index, tile.tile_pathname, tile.tile_type_id, tile.tile_class_id
-                from tile
-                join dataset on dataset.dataset_id=tile.dataset_id
-                where dataset.level_id = 100
-                ) as DSM on
-                        DSM.x_index=nbar.x_index and DSM.y_index=nbar.y_index
-                    and DSM.tile_type_id=nbar.tile_type_id and DSM.tile_class_id=nbar.tile_class_id
-            join
-                (
-                select
-                    dataset.acquisition_id, tile.dataset_id, tile.x_index, tile.y_index, tile.tile_pathname, tile.tile_type_id, tile.tile_class_id
-                from tile
-                join dataset on dataset.dataset_id=tile.dataset_id
-                where dataset.level_id = 110
-                ) as DEM on
-                        DEM.x_index=nbar.x_index and DEM.y_index=nbar.y_index
-                    and DEM.tile_type_id=nbar.tile_type_id and DEM.tile_class_id=nbar.tile_class_id
-            join
-                (
-                select
-                    dataset.acquisition_id, tile.dataset_id, tile.x_index, tile.y_index, tile.tile_pathname, tile.tile_type_id, tile.tile_class_id
-                from tile
-                join dataset on dataset.dataset_id=tile.dataset_id
-                where dataset.level_id = 120
-                ) as DEM_S on
-                        DEM_S.x_index=nbar.x_index and DEM_S.y_index=nbar.y_index
-                    and DEM_S.tile_type_id=nbar.tile_type_id and DEM_S.tile_class_id=nbar.tile_class_id
-            join
-                (
-                select
-                    dataset.acquisition_id, tile.dataset_id, tile.x_index, tile.y_index, tile.tile_pathname, tile.tile_type_id, tile.tile_class_id
-                from tile
-                join dataset on dataset.dataset_id=tile.dataset_id
-                where dataset.level_id = 130
-                ) as DEM_H on
-                        DEM_H.x_index=nbar.x_index and DEM_H.y_index=nbar.y_index
-                    and DEM_H.tile_type_id=nbar.tile_type_id and DEM_H.tile_class_id=nbar.tile_class_id
+                ) as FC on
+                    FC.acquisition_id=acquisition.acquisition_id
+                    and FC.x_index=NBAR.x_index and FC.y_index=NBAR.y_index
+                    and FC.tile_type_id=NBAR.tile_type_id and FC.tile_class_id=NBAR.tile_class_id
             where
-                nbar.tile_type_id = ANY(%(tile_type)s) and nbar.tile_class_id = ANY(%(tile_class)s) -- mandatory
+                NBAR.tile_type_id = ANY(%(tile_type)s) and NBAR.tile_class_id = ANY(%(tile_class)s) -- mandatory
                 and satellite.satellite_tag = ANY(%(satellite)s)
-                and nbar.x_index = ANY(%(x)s) and nbar.y_index = ANY(%(y)s)
+                and NBAR.x_index = ANY(%(x)s) and NBAR.y_index = ANY(%(y)s)
                 and end_datetime::date between %(acq_min)s and %(acq_max)s
 
             order by end_datetime {sort}, satellite asc

--- a/api/source/main/python/datacube/config.py
+++ b/api/source/main/python/datacube/config.py
@@ -86,11 +86,11 @@ class Config:
 
     def get_DbCredentials(self):
         return DbCredentials( \
-            self.get_db_host,
-            self.get_db_port,
-            self.get_db_database,
-            self.get_db_username,
-            self.get_db_password )
+            self.get_db_host(),
+            self.get_db_port(),
+            self.get_db_database(),
+            self.get_db_username(),
+            self.get_db_password() )
 
     # NOTE: This currently points to the datacube "DEV" server
     # Override by providing your own config file - for e.g. in $HOME/.datacube/.config
@@ -115,5 +115,9 @@ class DbCredentials(object):
         self.database = database
         self.user = user
         self.password = password
+
+    def __str__(self):
+        return "DbCredentials: host=%s,port=%d,database=%s,user=%s,password=%s" % \
+            (self.host, self.port, self.database, self.user, self.password)
         
 

--- a/api/source/main/python/datacube/config.py
+++ b/api/source/main/python/datacube/config.py
@@ -84,6 +84,14 @@ class Config:
     def to_str(self):
         return [(k.value, self._get_string(Config.Section.DATABASE, k)) for k in Config.DatabaseKey]
 
+    def get_DbCredentials(self):
+        return DbCredentials( \
+            self.get_db_host,
+            self.get_db_port,
+            self.get_db_database,
+            self.get_db_username,
+            self.get_db_password )
+
     # NOTE: This currently points to the datacube "DEV" server
     # Override by providing your own config file - for e.g. in $HOME/.datacube/.config
 
@@ -95,4 +103,17 @@ database: hypercube_v0
 username: cube_user
 password: GAcube0
 """
+
+class DbCredentials(object):
+    """
+    Class to hold all DbConnection credentials
+    """
+
+    def __init__(self, host, port, database, user, password):
+        self.host = host
+        self.port = port
+        self.database = database
+        self.user = user
+        self.password = password
+        
 

--- a/api/source/test/python/datacube/api/query_test.py
+++ b/api/source/test/python/datacube/api/query_test.py
@@ -91,7 +91,7 @@ def do_list_tiles_dtm_by_xy_single(config):
                            host=config.get_db_host(), port=config.get_db_port())
 
     for tile in tiles:
-        _log.info("Found tile xy = %s acq date = [%s] NBAR = [%s]", tile.xy, tile.end_datetime, tile.datasets[DatasetType.DSM].path)
+        _log.info("Found tile xy = %s acq date = [%s] DSM = [%s]", tile.xy, tile.end_datetime, tile.datasets[DatasetType.DSM].path)
 
 
 def do_list_cells_by_xy_single(config):

--- a/api/source/test/python/datacube/api/query_test.py
+++ b/api/source/test/python/datacube/api/query_test.py
@@ -33,7 +33,7 @@ __author__ = "Simon Oldfield"
 
 from datacube.api.model import DatasetType, Tile, Cell, Satellite
 from datacube.api.query import list_tiles, list_tiles_wkt, list_tiles_to_file, list_tiles_between_dates, list_cells, \
-    list_cells_to_file
+    list_cells_to_file, list_tiles_dtm
 import logging
 import os
 from datacube.config import Config
@@ -52,6 +52,8 @@ def main():
 
     do_list_tiles_by_xy_single(config)
     # do_list_cells_by_xy_single(config)
+
+    do_list_tiles_dtm_by_xy_single(config)
 
     # do_list_tiles_by_xy_multiple(config)
     # do_list_cells_by_xy_multiple(config)
@@ -73,6 +75,18 @@ def do_list_tiles_by_xy_single(config):
                        database=config.get_db_database(), user=config.get_db_username(),
                        password=config.get_db_password(),
                        host=config.get_db_host(), port=config.get_db_port())
+
+    for tile in tiles:
+        _log.debug("Found tile xy = %s acq date = [%s]", tile.xy, tile.end_datetime)
+
+
+def do_list_tiles_dtm_by_xy_single(config):
+    tiles = list_tiles_dtm(x=[123], y=[-25],
+                           datasets=[DatasetType.DSM, DatasetType.DEM, DatasetType.DEM_HYDROLOGICALLY_ENFORCED,
+                                     DatasetType.DEM_SMOOTHED],
+                           database=config.get_db_database(), user=config.get_db_username(),
+                           password=config.get_db_password(),
+                           host=config.get_db_host(), port=config.get_db_port())
 
     for tile in tiles:
         _log.debug("Found tile xy = %s acq date = [%s]", tile.xy, tile.end_datetime)

--- a/api/source/test/python/datacube/api/query_test.py
+++ b/api/source/test/python/datacube/api/query_test.py
@@ -45,7 +45,7 @@ _log = logging.getLogger()
 
 
 def main():
-    logging.basicConfig(level=logging.DEBUG)
+    logging.basicConfig(level=logging.INFO)
 
     config = Config(os.path.expanduser("~/.datacube/config"))
     _log.debug(config.to_str())
@@ -69,6 +69,7 @@ def main():
 
 
 def do_list_tiles_by_xy_single(config):
+    _log.info("Testing list_tiles...")
     tiles = list_tiles(x=[123], y=[-25], acq_min=date(2002, 1, 1), acq_max=date(2002 ,12, 31),
                        satellites=[Satellite.LS7],
                        datasets=[DatasetType.ARG25, DatasetType.PQ25, DatasetType.FC25],
@@ -77,10 +78,11 @@ def do_list_tiles_by_xy_single(config):
                        host=config.get_db_host(), port=config.get_db_port())
 
     for tile in tiles:
-        _log.debug("Found tile xy = %s acq date = [%s]", tile.xy, tile.end_datetime)
+        _log.info("Found tile xy = %s acq date = [%s] NBAR = [%s]", tile.xy, tile.end_datetime, tile.datasets[DatasetType.ARG25].path)
 
 
 def do_list_tiles_dtm_by_xy_single(config):
+    _log.info("Testing list_tiles_dtm...")
     tiles = list_tiles_dtm(x=[123], y=[-25],
                            datasets=[DatasetType.DSM, DatasetType.DEM, DatasetType.DEM_HYDROLOGICALLY_ENFORCED,
                                      DatasetType.DEM_SMOOTHED],
@@ -89,7 +91,7 @@ def do_list_tiles_dtm_by_xy_single(config):
                            host=config.get_db_host(), port=config.get_db_port())
 
     for tile in tiles:
-        _log.debug("Found tile xy = %s acq date = [%s]", tile.xy, tile.end_datetime)
+        _log.info("Found tile xy = %s acq date = [%s] NBAR = [%s]", tile.xy, tile.end_datetime, tile.datasets[DatasetType.DSM].path)
 
 
 def do_list_cells_by_xy_single(config):

--- a/api/source/test/python/datacube/api/test_query_wrapper.py
+++ b/api/source/test/python/datacube/api/test_query_wrapper.py
@@ -1,0 +1,26 @@
+import os
+import unittest
+from datacube.config import Config, DbCredentials
+from datetime import datetime
+from datacube.api.query import list_tiles, TimeInterval, DatacubeQueryContext
+from datacube.api.model import DatasetType, Tile, Cell
+
+class TestQueryWrapper(unittest.TestCase):
+
+
+    def test_get_DbCredentials(self):
+
+        config = Config(os.path.expanduser("~/.datacube/config"))
+        start = datetime(1950,1,1)
+        end = datetime(2050,1,1)
+
+        tiles = list_tiles(x=[123], y=[-25], acq_min=start, acq_max=end, satellites=["LS7"],
+                       datasets=[DatasetType.ARG25, DatasetType.PQ25, DatasetType.FC25],
+                       database=config.get_db_database(), user=config.get_db_username(),
+                       password=config.get_db_password(),
+                       host=config.get_db_host(), port=config.get_db_port())
+
+        print len(tiles)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/api/source/test/python/datacube/api/test_query_wrapper.py
+++ b/api/source/test/python/datacube/api/test_query_wrapper.py
@@ -1,26 +1,39 @@
 import os
 import unittest
+from datacube.api.model import DatasetType, Tile, Cell, Satellite
 from datacube.config import Config, DbCredentials
 from datetime import datetime
-from datacube.api.query import list_tiles, TimeInterval, DatacubeQueryContext
-from datacube.api.model import DatasetType, Tile, Cell
+from datacube.api.query import list_tiles_as_list, TimeInterval, DatacubeQueryContext
+import logging
+
+logging.basicConfig(level=logging.INFO)
 
 class TestQueryWrapper(unittest.TestCase):
 
-
-    def test_get_DbCredentials(self):
-
+    def test_get_tiles_base_api(self):
         config = Config(os.path.expanduser("~/.datacube/config"))
         start = datetime(1950,1,1)
         end = datetime(2050,1,1)
 
-        tiles = list_tiles(x=[123], y=[-25], acq_min=start, acq_max=end, satellites=["LS7"],
-                       datasets=[DatasetType.ARG25, DatasetType.PQ25, DatasetType.FC25],
-                       database=config.get_db_database(), user=config.get_db_username(),
-                       password=config.get_db_password(),
+        tiles = list_tiles_as_list(x=[123], y=[-25], acq_min=start, acq_max=end, \
+                       satellites=[Satellite.LS7],
+                       datasets=[DatasetType.ARG25, DatasetType.PQ25, DatasetType.FC25], \
+                       database=config.get_db_database(), user=config.get_db_username(), \
+                       password=config.get_db_password(), \
                        host=config.get_db_host(), port=config.get_db_port())
+        self.assertEqual(len(tiles), 327)
 
-        print len(tiles)
+    def test_get_tiles_with_cube_context(self):
+        config = Config(os.path.expanduser("~/.datacube/config"))
+        time_interval = TimeInterval(datetime(1950,1,1), datetime(2050,1,1))
+        print "type of time_interval = %s" % type(time_interval)
+        satellite_list = [Satellite.LS7]
+        dataset_list = [DatasetType.ARG25, DatasetType.PQ25, DatasetType.FC25]
+
+        cube = DatacubeQueryContext(config.get_DbCredentials())
+        tiles = cube.tile_list([123], [-25], satellite_list, time_interval, dataset_list)
+
+        self.assertEqual(len(tiles), 327)
 
 if __name__ == '__main__':
     unittest.main()

--- a/api/source/test/python/datacube/api/test_query_wrapper.py
+++ b/api/source/test/python/datacube/api/test_query_wrapper.py
@@ -21,7 +21,7 @@ class TestQueryWrapper(unittest.TestCase):
                        database=config.get_db_database(), user=config.get_db_username(), \
                        password=config.get_db_password(), \
                        host=config.get_db_host(), port=config.get_db_port())
-        self.assertEqual(len(tiles), 327)
+        self.assertEqual(len(tiles), 523)
 
     def test_get_tiles_with_cube_context(self):
         config = Config(os.path.expanduser("~/.datacube/config"))
@@ -33,7 +33,37 @@ class TestQueryWrapper(unittest.TestCase):
         cube = DatacubeQueryContext(config.get_DbCredentials())
         tiles = cube.tile_list([123], [-25], satellite_list, time_interval, dataset_list)
 
-        self.assertEqual(len(tiles), 327)
+        self.assertEqual(len(tiles), 523)
+
+
+    def test_get_tiles_to_file_with_cube_context(self):
+        config = Config(os.path.expanduser("~/.datacube/config"))
+        time_interval = TimeInterval(datetime(1950,1,1), datetime(2050,1,1))
+        print "type of time_interval = %s" % type(time_interval)
+        satellite_list = [Satellite.LS7]
+        dataset_list = [DatasetType.ARG25, DatasetType.PQ25, DatasetType.FC25]
+
+        cube = DatacubeQueryContext(config.get_DbCredentials())
+        tiles = cube.tiles_to_file([123], [-25], satellite_list, time_interval, dataset_list, \
+                 "tmp.txt")
+
+#        self.assertEqual(len(tiles), 523)
+
+    def test_get_all_tiles_with_cube_context(self):
+        logging.info("get_all_tiles started")
+        config = Config(os.path.expanduser("~/.datacube/config"))
+        time_interval = TimeInterval(datetime(1950,1,1), datetime(2050,1,1))
+        satellite_list = [Satellite.LS7, Satellite.LS5, Satellite.LS8]
+        dataset_list = [DatasetType.ARG25, DatasetType.PQ25]
+
+        cube = DatacubeQueryContext(config.get_DbCredentials())
+        tiles = cube.tiles_to_file(range(111, 154), range(-46, 4), satellite_list, time_interval, \
+            dataset_list, "tmp.txt")
+
+        logging.info("get_all_tiles finished")
+
+#        self.assertEqual(len(tiles), 523)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/api/source/test/python/datacube/api/wofs_testing.md
+++ b/api/source/test/python/datacube/api/wofs_testing.md
@@ -5,7 +5,7 @@ WOFS Testing
 Getting all tiles
 -----------------
 
-This tests looks at the simple use case of getting all NBAR, PQ and DSM tiles from the datacube. 
+This test looks at the simple use case of getting all NBAR, PQ and DSM tiles from the datacube. 
 
 See [the code](https://github.com/GeoscienceAustralia/agdc/blob/stevenring/api/api/source/test/python/datacube/api/wofs_use_case_tests.py)
 ```

--- a/api/source/test/python/datacube/api/wofs_testing.md
+++ b/api/source/test/python/datacube/api/wofs_testing.md
@@ -1,0 +1,22 @@
+==========================
+WOFS Testing
+==========================
+
+Getting all tiles
+-----------------
+
+This tests looks at the simple use case of getting all NBAR, PQ and DSM tiles from the datacube. 
+
+See [the code](https://github.com/GeoscienceAustralia/agdc/blob/stevenring/api/api/source/test/python/datacube/api/wofs_use_case_tests.py)
+```
+[smr547@raijin4 api]$ python wofs_use_case_tests.py
+02-12 16:17 root         INFO     get_all_tiles started
+02-12 16:19 root         INFO     get_all_tiles finished
+.
+----------------------------------------------------------------------
+Ran 1 test in 97.736s
+  
+OK
+[smr547@raijin4 api]$ cat wofs_tiles.csv | wc -l
+997374
+```

--- a/api/source/test/python/datacube/api/wofs_use_case_tests.py
+++ b/api/source/test/python/datacube/api/wofs_use_case_tests.py
@@ -1,0 +1,52 @@
+import os
+import unittest
+from datacube.api.model import DatasetType, Tile, Cell, Satellite
+from datacube.config import Config, DbCredentials
+from datetime import datetime
+from datacube.api.query import list_tiles_as_list, TimeInterval, DatacubeQueryContext
+import logging
+
+logging.basicConfig(level=logging.INFO, \
+    format='%(asctime)s %(name)-12s %(levelname)-8s %(message)s', datefmt='%m-%d %H:%M')
+
+class TestQueryWrapper(unittest.TestCase):
+
+    def test_get_all_tiles_for_WOfS_processing(self):
+        """
+        This test demonstrates how to get all tiles relevant to WOfS processing
+        for the entire continent over all time
+        """
+
+        logging.info("get_all_tiles started")
+
+        # get a CubeQueryContext (this is a wrapper around the API)
+
+        config = Config(os.path.expanduser("~/.datacube/config"))
+        cube = DatacubeQueryContext(config.get_DbCredentials())
+
+        # we are interested in all time
+
+        time_interval = TimeInterval(datetime(1950,1,1), datetime(2050,1,1))
+
+        # all landsat satellites
+
+        satellite_list = [Satellite.LS7, Satellite.LS5, Satellite.LS8]
+
+        # NBAR, PQ and DSM
+
+        dataset_list = [DatasetType.ARG25, DatasetType.PQ25]
+
+        # now get the tile list and write it to a working file
+
+        wofs_tiles = "./wofs_tiles.csv"
+        tiles = cube.tiles_to_file(range(111, 154), range(-46, 4), satellite_list, time_interval, \
+            dataset_list, wofs_tiles)
+
+        # all done
+
+        self.assertTrue(os.path.exists(wofs_tiles))
+        logging.info("get_all_tiles finished")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Some things to be thrown into the API thinking pot:

New TimeInterval class allows start and end dates to be encapsulated in one instance reducing the number of query tile_list() parameters by one. Inspired by Java Joda package.

There seems to be no need for a the tile_list method which takes a "year" list:

``interval = TimeInterval(datetime(2000,1,1), datettime(2003,12,31))``

is equivalent to 

``years = range(2000,2004)`` 

Instances of new DbCredentials credentials class carry database credentials reducing the number of query tile_list() parameters by 4. Factory method in ``config`` module creates instances of DbCredentials from existing config.

Instance of new DatacubeQueryContext class carries a DbCredentials instance and offers simplified api calls (5 fewer parameters). Methods delegate to the existing api functions.