### PR TITLE
Increase GDAL memory sizes for improved compression and ingest speed.

### DIFF
--- a/agdc/abstract_ingester/tile_contents.py
+++ b/agdc/abstract_ingester/tile_contents.py
@@ -66,7 +66,7 @@ PQA_CONTIGUITY = 256  # contiguity = bit 8
 
 GDAL_CACHEMAX_MB = 500
 # Working buffers (in MB)
-GDAL_WM_MB = 500
+# GDAL_WM_MB = 500
 
 
 class TileContents(object):
@@ -213,7 +213,8 @@ def _create_reproject_command(band_stack, first_file_number, nodata_value, temp_
     reproject_cmd = [
         "gdalwarp",
         '--config', 'GDAL_CACHEMAX', str(GDAL_CACHEMAX_MB),
-        '-wm', str(GDAL_WM_MB),
+        # Changing the warp memory size altered pixel values. Disable until further tests are performed.
+        # '-wm', str(GDAL_WM_MB),
         "-q",
         "-of",
         "%s" % tile_type_info['file_format'],
@@ -239,7 +240,6 @@ def _create_reproject_command(band_stack, first_file_number, nodata_value, temp_
         "%s" % band_stack.vrt_name,
         "%s" % temp_tile_output_path  # Use locally-defined output path, not class instance value
     ])
-    return reproject_cmd
 
 
 def _reproject(tile_type_info, tile_footprint, band_stack, output_path):

--- a/agdc/abstract_ingester/tile_contents.py
+++ b/agdc/abstract_ingester/tile_contents.py
@@ -53,6 +53,7 @@ from EOtools.utils import log_multiline
 from ..cube_util import DatasetError, create_directory, get_file_size_mb
 
 
+
 # Set up LOGGER.
 LOGGER = logging.getLogger(__name__)
 LOGGER.setLevel(logging.INFO)
@@ -62,6 +63,10 @@ LOGGER.setLevel(logging.INFO)
 #
 
 PQA_CONTIGUITY = 256  # contiguity = bit 8
+
+GDAL_CACHEMAX_MB = 500
+# Working buffers (in MB)
+GDAL_WM_MB = 500
 
 
 class TileContents(object):
@@ -207,6 +212,8 @@ def _create_reproject_command(band_stack, first_file_number, nodata_value, temp_
     tile_extents = _tile_extents(tile_footprint, tile_type_info)
     reproject_cmd = [
         "gdalwarp",
+        '--config', 'GDAL_CACHEMAX', str(GDAL_CACHEMAX_MB),
+        '-wm', str(GDAL_WM_MB),
         "-q",
         "-of",
         "%s" % tile_type_info['file_format'],


### PR DESCRIPTION
These commits are from December, but we never followed through to merge them.

The default GDAL memory sizes are tiny. By bumping them up, compression improves significantly (output files were half the size), and ingest time on our test data dropped from four minutes to around one minute in the NCI environment.

The output files are identical at the pixel level (the improved compression is presumably due to a much larger window size).