### PR TITLE
Include the Modis ingester in the agdc package.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(name='agdc',
       packages = [
                   'agdc',
                   'agdc.abstract_ingester',
+                  'agdc.modis_ingester',
                   'agdc.landsat_ingester'
                   ],
       package_data = {


### PR DESCRIPTION
The Modis ingester is not currently included during `setup.py install`.