### PR TITLE
Make 'path' config optional for Modis ingestion.

### DIFF
--- a/agdc/modis_ingester/__init__.py
+++ b/agdc/modis_ingester/__init__.py
@@ -106,11 +106,12 @@ class ModisIngester(SourceFileIngester):
         Overridden to allow NULLS for row
         """
         (start_date, end_date) = self.get_date_range()
-        (min_path, max_path) = self.get_path_range()
-        (min_row, max_row) = self.get_row_range()
 
-        include = ((int(max_path) is None or path is None or int(path) <= int(max_path)) and
-                   (int(min_path) is None or path is None or int(path) >= int(min_path)) and
+        # Modis 'path' is actually the Orbit number.
+        (min_path, max_path) = self.get_path_range()
+
+        include = ((max_path is None or path is None or int(path) <= int(max_path)) and
+                   (min_path is None or path is None or int(path) >= int(min_path)) and
                    (end_date is None or date is None or date <= end_date) and
                    (start_date is None or date is None or date >= start_date))
 


### PR DESCRIPTION
The Modis ingester fails when no path/row constraints are specified (it tries to convert None to int). 

Previous tests appear to have worked around this by setting large min/max values (-99999 and 99999), but a better solution is to make the values optional.
